### PR TITLE
Improved Documentation of `updateDnsRecords`

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -449,8 +449,10 @@ class API {
      * Update DNS records of a zone. Deletion of other records is optional.
      * When DNSSEC is active, the zone is updated in the nameserver with zone resign after a few minutes.
      *
+     * For more options for every DNS record see https://ccp.netcup.net/run/webservice/servers/endpoint.php#Dnsrecord
+     *
      * @param string $domainName
-     * @param $dnsRecordSet
+     * @param array{"dnsrecords": array{"id": string, "hostname": string, "type": string, "priority": string, "destination": string}[]} $dnsRecordSet
      * @return Response
      * @throws NotLoggedInException
      * @throws NetcupException


### PR DESCRIPTION
To update DNS records I used to do:

```php
/** @var DnsRecord[] $dnsRecords */
/** @var Domain $domain*/
$api->updateDnsRecords($domain->getDomainName(), $dnsRecords);
```
Which fails with this error:

```json
{
  "serverrequestid": "<server-request-id>",
  "clientrequestid": "<client-request-id>",
  "action": "updateDnsRecords",
  "status": "error",
  "statuscode": 4018,
  "shortmessage": "Update of DNS records failed",
  "longmessage": "The DNS records are not in valid format.",
  "responsedata": ""
}
```

Seems like the method needs to be called like this:

```php
$api->updateDnsRecords($domain->getDomainName(), ['dnsrecords' => $dnsRecords]);
```

I've updated the documentation of the method.