### PR TITLE
NetcupException Now Contains the Full Response Object

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -157,7 +157,7 @@ class API {
             'email'        => $email
         ]);
         if(!$response->wasSuccessful()) {
-            throw new NetcupException($response->getData());
+            throw new NetcupException($response);
         }
         return new Handle($this, $response->getData());
     }
@@ -217,7 +217,7 @@ class API {
             'domainname' => $domainName
         ]);
         if(!$response->wasSuccessful() || !isset($response->getData()->dnsrecords)) {
-            throw new NetcupException($response->getData());
+            throw new NetcupException($response);
         }
         $records = [];
         foreach($response->getData()->dnsrecords as $recordRaw) {
@@ -268,7 +268,7 @@ class API {
         try {
             $response = $this->request('infoDomain', ['domainname' => $domainName]);
             if(!$response->wasSuccessful()) {
-                throw new NetcupException($response->getData());
+                throw new NetcupException($response);
             }
             if($response->getData()?->state == 'not registered at netcup') {
                 throw new NotRegisteredAtNetcupException();
@@ -297,7 +297,7 @@ class API {
             'handle_id' => $handleId
         ]);
         if(!$response->wasSuccessful()) {
-            throw new NetcupException($response->getData());
+            throw new NetcupException($response);
         }
         return new Handle($this, $response->getData());
     }
@@ -316,7 +316,7 @@ class API {
         }
         $response = $this->request('listallDomains');
         if(!$response->wasSuccessful()) {
-            throw new NetcupException($response->getData());
+            throw new NetcupException($response);
         }
 
         $domains = [];
@@ -341,7 +341,7 @@ class API {
 
         $response = $this->request('listallHandle');
         if(!$response->wasSuccessful()) {
-            throw new NetcupException($response->getData());
+            throw new NetcupException($response);
         }
 
         $handles = [];
@@ -387,7 +387,7 @@ class API {
         }
         $response = $this->request('logout');
         if(!$response->wasSuccessful()) {
-            throw new NetcupException($response->getData());
+            throw new NetcupException($response);
         }
 
         if(!$response->wasSuccessful()) {
@@ -562,7 +562,7 @@ class API {
             'email'        => $email
         ]);
         if(!$response->wasSuccessful()) {
-            throw new NetcupException($response->getData());
+            throw new NetcupException($response);
         }
         return new Handle($this, $response->getData());
     }

--- a/src/Exception/NetcupException.php
+++ b/src/Exception/NetcupException.php
@@ -12,9 +12,9 @@ class NetcupException extends \Exception {
     public function __construct(null|Response|stdClass $response = null) {
         if ($response instanceof stdClass) {
             // Backward compatibility in case someone out there is creating a NetcupException
-            $rawResponse = new stdClass();
+            $rawResponse               = new stdClass();
             $rawResponse->responsedata = $response;
-            $response = new Response($rawResponse);
+            $response                  = new Response($rawResponse);
         }
         $this->response = $response;
         parent::__construct($response->getLongMessage() ?? '');

--- a/src/Exception/NetcupException.php
+++ b/src/Exception/NetcupException.php
@@ -2,19 +2,35 @@
 
 namespace Netcup\Exception;
 
+use Netcup\Response\Response;
 use stdClass;
 
 class NetcupException extends \Exception {
 
-    private stdClass $response;
+    private ?Response $response;
 
-    public function __construct(stdClass $response = null) {
-        if($response != null) {
-            $this->response = $response;
+    public function __construct(null|Response|stdClass $response = null) {
+        if ($response instanceof stdClass) {
+            // Backward compatibility in case someone out there is creating a NetcupException
+            $rawResponse = new stdClass();
+            $rawResponse->responsedata = $response;
+            $response = new Response($rawResponse);
         }
+        $this->response = $response;
+        parent::__construct($response->getLongMessage() ?? '');
     }
 
+    /**
+     * Provides the `responsedata` entry of the http response
+     */
     public function getResponse(): ?stdClass {
+        return $this->response->getData();
+    }
+
+    /**
+     * Provides the complete Response object including error messages
+     */
+    public function getResponseObject(): ?Response {
         return $this->response;
     }
 }

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -23,6 +23,18 @@ class Response {
         return $this->rawResponse?->responsedata;
     }
 
+    public function getServerRequestId(): ?string {
+        return $this->rawResponse?->serverrequestid;
+    }
+
+    public function getClientRequestId(): ?string {
+        return $this->rawResponse?->clientrequestid;
+    }
+
+    public function getAction(): ?string {
+        return $this->rawResponse?->action;
+    }
+
     public function getStatus(): ?string {
         return $this->rawResponse?->status;
     }


### PR DESCRIPTION
While integrating the API I had a hard time to get to the reasons for errors, as the `NetcupException` does not include any data for api responses like this, as it only gets the `responsedata` key:

```json
{
  "serverrequestid": "<server-request-id>",
  "clientrequestid": "<client-request-id>",
  "action": "infoDnsRecords",
  "status": "error",
  "statuscode": 4001,
  "shortmessage": "Api session id in invalid format",
  "longmessage": "The session id is not in a valid format.",
  "responsedata": ""
}
```

I've adjusted the `NetcupException` to contain the complete response object and added getters for the other properties